### PR TITLE
Configurable OIDC redirect URI

### DIFF
--- a/amundsen-kube-helm/README.md
+++ b/amundsen-kube-helm/README.md
@@ -46,6 +46,7 @@ The following table lists the configurable parameters of the Amundsen charts and
 | frontEnd.OIDC_CLIENT_ID | string | `nil` | The client id for OIDC. |
 | frontEnd.OIDC_CLIENT_SECRET | string | `""` | The client secret for OIDC. |
 | frontEnd.OIDC_ORG_URL | string | `nil` | The organization URL for OIDC. |
+| frontEnd.OIDC_OVERWRITE_REDIRECT_URI | string | `nil` | The redirect URI/reply URL for OIDC. |
 | frontEnd.affinity | object | `{}` | Frontend pod specific affinity. |
 | frontEnd.createOidcSecret | bool | `false` | OIDC needs some configuration. If you want the chart to make your secrets, set this to true and set the next four values. If you don't want to configure your secrets via helm, you can still use the amundsen-oidc-config.yaml as a template |
 | frontEnd.imageVersion | string | `"2.0.0"` | The frontend version of the metadata container. |

--- a/amundsen-kube-helm/templates/helm/templates/amundsen-deployment.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/amundsen-deployment.yaml
@@ -149,6 +149,10 @@ spec:
           - name: FRONTEND_BASE
             value: http://{{ .Values.frontEnd.FRONTEND_BASE }}
           {{ end }}
+          {{- if .Values.frontEnd.OIDC_OVERWRITE_REDIRECT_URI }}
+          - name: FLASK_OIDC_REDIRECT_OVERRIDE
+            value: {{ .Values.frontEnd.OIDC_OVERWRITE_REDIRECT_URI }}
+          {{- end }}
           - name: SEARCHSERVICE_BASE
             value: http://{{ .Chart.Name }}-{{ .Values.search.serviceName }}:5001
           - name: METADATASERVICE_BASE

--- a/amundsen-kube-helm/templates/helm/templates/amundsen-oidc-config.yaml
+++ b/amundsen-kube-helm/templates/helm/templates/amundsen-oidc-config.yaml
@@ -31,7 +31,7 @@ stringData:
         "userinfo_uri": "{{ .Values.frontEnd.OIDC_ORG_URL }}/oauth2/{{ .Values.frontEnd.OIDC_AUTH_SERVER_ID }}/v1/userinfo",
         {{- end }}
         "redirect_uris": [
-          "http://localhost/oidc_callback"
+          "{{ .Values.frontEnd.OIDC_OVERWRITE_REDIRECT_URI }}"
         ],
         {{- if (eq .Values.frontEnd.OIDC_PROVIDER "azure") or (eq .Values.frontEnd.OIDC_PROVIDER "google") }}
         "token_introspection_uri": ""

--- a/amundsen-kube-helm/templates/helm/values.yaml
+++ b/amundsen-kube-helm/templates/helm/values.yaml
@@ -175,6 +175,10 @@ frontEnd:
   ## frontEnd.OIDC_AUTH_SERVER_ID -- The authorization server id for OIDC.
   ##
   OIDC_AUTH_SERVER_ID:
+  ##
+  ## frontEnd.OIDC_OVERWRITE_REDIRECT_URI -- The redirect URI/reply URL for OIDC.
+  ##
+  OIDC_OVERWRITE_REDIRECT_URI:
 
   ##
   ## frontEnd.resources -- See pod resourcing [ref](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/)


### PR DESCRIPTION
### Summary of Changes

Add the possibility to set a custom redirect URI/reply URL.
Sets an env var in the frontend deployment, which sets the following in the flask oidc wrapper:
https://github.com/jornh/flaskoidc/blob/jornh-flask_oidc_ex/flaskoidc/config.py#L27

This then sets OVERWRITE_REDIRECT_URI:
https://flask-oidc.readthedocs.io/en/latest/#custom-callback

### Documentation

Added comments to helm values file and readme.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely.
- [x] PR includes a summary of changes.
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
